### PR TITLE
Improve setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ recursive-include doc *
 recursive-include scripts *
 include AUTHORS
 include LICENSE
-include README.rst
+include README.md
 include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ salt>=0.16.2
 mysql-python
 simplejson
 argparse
+pyzmq

--- a/setup.py
+++ b/setup.py
@@ -3,37 +3,24 @@
 The setup script for salteventsd
 '''
 
-import os
-# Use setuptools only if the user opts-in by setting the USE_SETUPTOOLS env var
-# This ensures consistent behavior but allows for advanced usage with
-# virtualenv, buildout, and others.
-USE_SETUPTOOLS = False
-if 'USE_SETUPTOOLS' in os.environ:
-    try:
-        from setuptools import setup
-        USE_SETUPTOOLS = True
-    except:
-        USE_SETUPTOOLS = False
-
-
-if USE_SETUPTOOLS is False:
+try:
+    from setuptools import setup
+except ImportError:
     from distutils.core import setup
-
 
 # pylint: disable-msg=W0122,E0602
 exec(compile(open('salteventsd/version.py').read(), 'salteventsd/version.py', 'exec'))
 VERSION = __version__
 # pylint: enable-msg=W0122,E0602
 
-NAME = 'salt-eventsd'
-DESC = ("Daemon that collects events from the salt-event-bus and writes them into a database")
+with open('README.md') as f:
+    readme = f.read()
 
-kwargs = dict()
-
-kwargs.update(
-    name=NAME,
+setup(
+    name='salt-eventsd',
     version=VERSION,
-    description=DESC,
+    description="Daemon that collects events from the salt-event-bus and writes them into a database",
+    long_description=readme,
     author='Volker Schwicking',
     author_email='vs@hosteurope.de',
     url='http://saltstack.org',
@@ -49,19 +36,11 @@ kwargs.update(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Topic :: System :: Distributed Computing'],
+    install_requires=open('requirements.txt').readlines(),
     packages=['salteventsd'],
-    data_files=[('share/man/man1',
-        ['doc/man/salt-eventsd.1']),
-        ('share/man/man5',
-        ['doc/man/salt-eventsd.5'])],
+    data_files=[
+        ('share/man/man1', ['doc/man/salt-eventsd.1']),
+        ('share/man/man5', ['doc/man/salt-eventsd.5']),
+    ],
     scripts=['scripts/salt-eventsd'],
 )
-
-if USE_SETUPTOOLS:
-    kwargs.update(
-        install_requires=open('requirements.txt').readlines(),
-        test_suite='tests',
-    )
-
-setup(**kwargs)
-


### PR DESCRIPTION
Improvments for setup.py

 - Fixed typo in `MANIFEST.in` that pointed to wrong readme file
 - Removed opt-in for setuptools and for package dependencies. Package dependencies should be installed by default. Pip have the option `--no-deps` that should be used if you do not want to install any dependencies
 - Add missing dependency `pyzmq` that was not installed by default.
 - Added `long_description` so it can be rendered in pypi
 - No need to `test_suite` variable because there is no tests yet