### PR TITLE
Batch event worker

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,39 +1,55 @@
-### development version 0.9.1 Jan 19th 2015 ###
+### Placeholder for next release x.y.z ###
 
-* removed state_upd setting, it is replaced with a state_timer which fires every n seconds
+* Add support for batch mode by sending all events at once to a new `send_batch` method inside the worker. [Grokzen]
+
+* Add new example worker that uses the new batch mode (Grokzen)
+
+
+
+### stable version 0.9.1 Jan 19th 2015 ###
+
+* Removed state_upd setting, it is replaced with a state_timer which fires every n seconds
   to update the status file /var/run/salt-eventsd.status
 
-* added two new values to status-file:
+* Added two new values to status-file:
   - events_hdl_sec: the events the daemon has matched against its config per second
   - events_tot_sec: the total events received on the eventbus per second
 
-  the old values are still there:
+  The old values are still there:
   - events_hdl: the total count of events handled
   - events_rec: the total count of events received
   - threads_created: the total number of threads created
   - threads_joined: the total number of threads joined
 
-* added a Stat_Worker that pushes the values found in the status-file into a worker
+* Added a Stat_Worker that pushes the values found in the status-file into a worker
   to push them even further into a backend. this greatly simplifies monitoring
 
-* code improvements from grokez, mainly PEP8
-* code improvements from grokez, specify config file on the cli (-c)
-* setup.py improvements from grokez for pypi (in the works)
+* Code improvements mainly PEP8 (Grokzen)
+
+* Code improvements specify config file on the cli (-c) (Grokzen)
+
+* Improved setup.py for pypi release (Grokzen)
+
+* First release to be uploaded to pypi
 
 
 
 ### stable version 0.9, Oct 26th 2014 ###
 
-* handle CTRL+C properly when run in foreground
-* cosmetic changes to docstrings, comments and tracking of files in git
-* fix requirements.txt for pip-users
-* tag 0.9 ist current stable release
+* Handle CTRL+C properly when run in foreground
+
+* Cosmetic changes to docstrings, comments and tracking of files in git
+
+* Fix requirements.txt for pip-users
 
 
 
 ### stable version 0.8, Aug 31st 2014 ###
 
 * Prio 1 events added to push events immediately without queing them first
+
 * Improved daemon handling on the console by addind argparse options, partly fixes #5
+
 * Fixed issues #7 #8 #9
+
 * Added changelog to show more easily what has changed

--- a/doc/share/doc/eventsd.batch
+++ b/doc/share/doc/eventsd.batch
@@ -1,0 +1,76 @@
+###### GENERAL CONFIGURATION SETTINGS #######
+#############################################
+# general configuration settings for the daemon. Do not
+# remove any unless you really know what you're doing!
+general: 
+    # where is the socket for the events located
+    # /var/run/salt/master for salt-master
+    # /var/run/salt/minion for the salt-minion
+    # when run on a minion, always set 'node' to 'minion' too
+    sock_dir: /var/run/salt/master
+    node: master
+    # the id the listener should use while listening for events
+    # can by anything, but 'master' is advised on salt-master
+    id: master
+    # how many concurrent workers to start at most
+    max_workers: 100
+    # how many events to collect before starting a worker 
+    # that dumps the collected events into the database
+    # i suggest starting with one and raising it once it works
+    event_limit: 20
+    # where the daemon should put its pidfile
+    pidfile: /var/run/salt-eventsd.pid
+    # where the daemon should put its state_file
+    # this is plain text, just cat it
+    state_file: /var/run/salt-eventsd.status
+    # how frequently (after how many collected events) to 
+    # update the state_file
+    state_timer: 25
+    # the loglevel to use for logging
+    loglevel: debug
+    # the logfile the daemon should log into
+    logfile: /var/log/salt/eventsd
+    # after how many seconds with no collected events should the daemon
+    # start a worker to put the already collected events into the database
+    dump_timer: 10
+    # the backends to load on daemon-start, see the documentation in 
+    # /usr/share/doc/salt-eventsd/backends.txt on how to write your own
+    backends: [Minion_Batch_Return_Worker]
+    # where to find the active backends 
+    backend_dir: /etc/salt/eventsd_workers
+
+
+##### CREDENTIALS FOR THE WORKERS #############
+###############################################
+# add each worker with its name and its credentials here.
+# if no worker is defined but an entry called 'all'
+# exists, all worker will use the settings from global
+worker_settings:
+    # this entry will be used by any worker that is not explicitly defined
+    all:
+        redis-host: localhost
+        redis-port: 6379
+
+###### EVENT CONFIGURATION SETTINGS #######
+#############################################
+# The events the daemon should collect from the events bus.
+#
+events: 
+    batch_return: 
+        # This event matches on ALL results returned from a minion 
+
+        # The tag is defined as regex. Any regex python supports is supported
+        # but has to be escaped (if necessary) and quoted to work.
+        tag:  salt/job/[0-9]*/ret/\w+
+        # the backend where to send events that match this tag
+        backend: Minion_Batch_Return_Worker
+        # the dictionary-name WITHIN the returned event-dictionary 
+        # that holds the data we're interested in.
+        dict_name: data
+        # the fields from the dict_name-dictionary we want in the query. always make sure, 
+        # that the order in the template above and the fields defined here match in count
+        fields: [jid, id, retcode, return, success]
+        # enable debugging for this event
+        debug: false
+        # Enable batch mode
+        batch_mode: true

--- a/doc/share/doc/eventsd_workers/Minion_Batch_Return_Worker.py
+++ b/doc/share/doc/eventsd_workers/Minion_Batch_Return_Worker.py
@@ -1,0 +1,76 @@
+'''
+this Worker takes care of return-data being returned by a minion.
+it takes care of dumping the 'return'-field into the database
+after its json-encoded and base64 converted.
+'''
+
+# import and setup logger first, so we can catch
+# missing libraries on imports
+import logging
+import redis
+
+log = logging.getLogger(__name__)
+
+
+class Minion_Batch_Return_Worker(object):
+    '''
+    takes care of dumping 'return'-data into the database
+    '''
+    # the settings for the mysql-server to use
+    settings = {}
+    name = "Minion_Batch_Return_Worker"
+    thread_id = None
+
+    def setup(self, thread_id, **kwargs):
+        '''
+        Setup the worker and read all settings
+        '''
+        self.thread_id = thread_id
+
+        # get the settings from the main config in kwargs
+        if 'worker_settings' in kwargs:
+            if self.name in kwargs['worker_settings']:
+                self.settings.update(kwargs['worker_settings'][self.name])
+            elif 'all' in kwargs['worker_settings']:
+                self.settings.update(kwargs['worker_settings']['all'])
+            else:
+                log.info('{0}# no settings loaded from config'.format(self.thread_id))
+
+        self.redis_host = self.settings['redis-host']
+        self.redis_port = self.settings['redis-port']
+
+        # keep track of the events dumped
+        self.dumped = 0
+
+        log.info("{0}# Worker '{1}' initiated".format(self.thread_id, self.name))
+
+    def shutdown(self):
+        '''
+        '''
+        log.info("{0}# dumped {1} events to {2}".format(
+            self.thread_id,
+            self.dumped,
+            self.redis_host,
+        ))
+
+    def send_batch(self, events):
+        """
+        Get all events
+        """
+        r = redis.StrictRedis(
+            host=self.redis_host,
+            port=self.redis_port,
+        )
+
+        pipe = r.pipeline()
+
+        for event_tuple in events:
+            event = event_tuple[0]
+            # event_set = event_tuple[1]
+
+            pipe.set("{0}".format(
+                event["data"]["jid"]),
+                event["data"]["return"],
+            )
+
+        pipe.execute()


### PR DESCRIPTION
This fixes issue #28 

 - Added support for a optional mode to send all queued up events at the same time to each worker instead of sending them one by one like the normal way of doing it.
 - Updated changelog
 - Added new example worker for this new batch mode.