### PR TITLE
Make simplejson dependency optional instead of required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ certain events can be collected by their tag and/or function-name and handed dow
 workers then extract the desired data-fields from the return and process them further in a user-definable way.
 
 
+### Dependencies
+
+Required python runtime dependencies:
+
+ - salt >= 0.16.2
+ - mysql-python
+ - argparse
+ - pyzmq
+
+Optional/usefull dependencies
+
+ - simplejson (Install with: pip install simplejson)
+
+
 ### Usage Examples
 
 - collect all events with tag 'new_job' to have a job-history that lasts longer than saltstacks job-cache

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,6 @@ Depends: ${python:Depends},
          python,
          salt-master,
          python-mysqldb,
-         python-simplejson,
          python-zmq,
          python-yaml
 Description: A configurable daemon that listens on salts event-bus. It can react 

--- a/doc/share/doc/eventsd_workers/Minion_Return_Worker.py
+++ b/doc/share/doc/eventsd_workers/Minion_Return_Worker.py
@@ -11,7 +11,11 @@ import logging
 log = logging.getLogger(__name__)
 
 try:
-    import simplejson
+    import simplejson as json
+except ImportError:
+    import json
+
+try:
     from base64 import b64encode
     import MySQLdb
 except ImportError as mis_lib:
@@ -134,7 +138,7 @@ class Minion_Return_Worker(object):
                 if fld == 'return':
                     tgt_data.append(
                         b64encode(
-                            simplejson.dumps(
+                            json.dumps(
                                 src_data[fld]
                             )
                         )

--- a/doc/share/doc/eventsd_workers/Minion_Sub_Worker.py
+++ b/doc/share/doc/eventsd_workers/Minion_Sub_Worker.py
@@ -11,7 +11,11 @@ import logging
 log = logging.getLogger(__name__)
 
 try:
-    import simplejson
+    import simplejson as json
+except ImportError:
+    import json
+
+try:
     from base64 import b64encode
     import MySQLdb
 except ImportError as mis_lib:
@@ -131,7 +135,7 @@ class Minion_Sub_Worker(object):
                 if fld == 'return':
                     tgt_data.append(
                         b64encode(
-                            simplejson.dumps(
+                            json.dumps(
                                 src_data[fld]
                             )
                         )

--- a/doc/share/doc/eventsd_workers/New_Job_Worker.py
+++ b/doc/share/doc/eventsd_workers/New_Job_Worker.py
@@ -13,7 +13,11 @@ import logging
 log = logging.getLogger(__name__)
 
 try:
-    import simplejson
+    import simplejson as json
+except ImportError:
+    import json
+
+try:
     from base64 import b64encode
     import MySQLdb
     from socket import gethostname
@@ -150,7 +154,7 @@ class New_Job_Worker(object):
                 if fld == 'arg':
                     tgt_data.append(
                         b64encode(
-                            simplejson.dumps(
+                            json.dumps(
                                 src_data[fld]
                             )
                         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 salt>=0.16.2
 mysql-python
-simplejson
 argparse
 pyzmq

--- a/salteventsd/daemon.py
+++ b/salteventsd/daemon.py
@@ -15,10 +15,14 @@ for events, collects events and starts all the workers to dump data.
 import logging
 import os
 import signal
-import simplejson
 import sys
 import time
 from re import compile
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 # salt-eventsd imports
 from salteventsd.backends import BackendMngr
@@ -515,7 +519,7 @@ class SaltEventsDaemon(Daemon):
             # write the info to the specified log
             statf = open(self.state_file, 'w')
             statf.writelines(
-                simplejson.dumps({
+                json.dumps({
                     'events_rec': self.events_rec,
                     'events_hdl': self.events_han,
                     'events_hdl_sec': round(ev_hdl_per_s, 2),


### PR DESCRIPTION
There is no need to have simplejson as a required dependency, the std lib json implementation works equally as good and we do not have any super massive config files that we read that requires us to have best json performance.

I documented it in the readme that is is a optional dependency and in all code it tires to import simplejson first and falls back on std lib json if that fails.