### PR TITLE
Update changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,9 @@ salt-eventsd (0.9.2) stable; urgency=low
 
   * New send_batch()-method for workers (PR #22, thx Grokzen)
   * Fix for issue #29
-
+ 
+ -- Volker Schwicking <volker.schwicking@heg.com>  Thu, 22 Jan 2015 07:29:57 +0200
+ 
 salt-eventsd (0.9.1) stable; urgency=low
 
   * coding style improvements and cleanup of pep8 violations (PR #20, thx Grokzen)


### PR DESCRIPTION
The changelog is broken (missing author in 0.9.2) which prevents `dpkg-buildpackage` from building the package.