### PR TITLE
Optional mysql & elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ workers then extract the desired data-fields from the return and process them fu
 Required python runtime dependencies:
 
  - salt >= 0.16.2
- - mysql-python
  - argparse
  - pyzmq
 
 Optional/usefull dependencies
 
- - simplejson (Install with: pip install simplejson)
+ - simplejson (pip install simplejson)
+ - mysql (pip install mysql-python)
+ - redis (pip install redis)
+ - elasticsearch (pip install elasticsearch>=1.0.0,<2.0.0)
 
 
 ### Usage Examples
@@ -108,6 +110,28 @@ were done for example to a reactor or a runner.
 - create your own sql-query-templates for inserting data into the database
 - fully saltstack-job-cache independant database to hold all data you want in it
 - example workers are found in the doc-directory
+
+
+### Worker installation
+
+No workers is installed by default when installing eventsd. Some workers require additional python requirements to make them work and you have to install them yourself when you are installing the worker files.
+
+The available workers can be found in the [eventsd_workers](doc/share/doc/eventsd_workers) folder.
+
+The following workers require `mysql-python` python package to be installed
+
+ - [Minion_Return_Worker.py](doc/share/doc/eventsd_workers/Minion_Return_Worker.py)
+ - [Minion_Sub_Worker.py](doc/share/doc/eventsd_workers/Minion_Sub_Worker.py)
+ - [New_Job_Worker.py](doc/share/doc/eventsd_workers/New_Job_Worker.py)
+ - [Stat_Worker.py](doc/share/doc/eventsd_workers/Stat_Worker.py)
+
+The following workers require `redis` python package to be installed
+
+ - [Minion_Batch_Return_Worker.py](doc/share/doc/eventsd_workers/Minion_Batch_Return_Worker.py)
+
+The following workers require `elasticsearch>=1.0.0,<2.0.0` python package to be installed
+
+ - [Elasticsearch_Worker.py](doc/share/doc/eventsd_workers/Elasticsearch_Worker.py)
 
 
 ### Testing

--- a/changelog
+++ b/changelog
@@ -3,6 +3,9 @@
 * the munin-plugin multips_memory requires the process name to be '/usr/bin/python....' instead of
   'python...' to work properly
 
+* Remove mysql and elasticsearch as requirements for this package and document the need to install them manually
+  if the workers that require them is going to be used. (Grokzen)
+
 
 
 ### stable version 0.9.3 ###

--- a/installation.txt
+++ b/installation.txt
@@ -45,14 +45,17 @@ I  It will create two tables:
    - New_Job_Worker.py -> for writing new commands into mysql
    - Minion_Return_Worker.py -> for writing returns into mysql
 
-5. (Re)start the daemon with its init-skript and the data should start coming in
+5. Install the mysql dependency to enable the workers to connect to a mysql server.
+   Run 'pip install mysql-python' to install the package.
+
+6. (Re)start the daemon with its init-skript and the data should start coming in
    once you issue a few commands to your minions. issued commands can be found in the
    'cmd_hist'-table, the results in 'returns'. dont be confused if you see base64
    encoded data. salt-eventsd does this with various fields to ensure, that characters
    within the data to insert do not break the mysql-query (which can easily happen with
    python data-structures). all data base64 is also json-encoded for easy extraction.
 
-6. If you dont see any data coming in, see the debug section below and tail the logfile
+7. If you dont see any data coming in, see the debug section below and tail the logfile
    /var/log/salt/eventsd
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 salt>=0.16.2
-mysql-python
 argparse
 pyzmq
-elasticsearch>=1.0.0,<2.0.0


### PR DESCRIPTION
This removes the install dependency for mysql and elasticsearch and adds documentation to README.md about what workers require what extra dependencies when they are used.

Argument for this is that in my installation i do not use any of the bundled workers but only my own custom that do not use mysql, redis or elasticsearch. Because of that i have no need for those dependencies but i am currently required to install them because they are in setup.py.