### PR TITLE
Fixing issue where processing stops when the salt master restarts

### DIFF
--- a/salteventsd/daemon.py
+++ b/salteventsd/daemon.py
@@ -374,6 +374,13 @@ class SaltEventsDaemon(Daemon):
             except KeyboardInterrupt:
                 log.info('Received CTRL+C, shutting down')
                 self.stop(signal.SIGTERM, None)
+            except AssertionError:
+                # Incase the master restarts a reconnect needs to happen.
+                event = salt.utils.event.SaltEvent(
+                    self.node,
+                    self.sock_dir,
+                )
+                ret = event.get_event(full=True)
 
             # if we have not received enough events in to reach event_limit
             # and the timer has fired, dump the events collected so far


### PR DESCRIPTION
This fixes https://github.com/felskrone/salt-eventsd/issues/47

Tested on both salt-master 2015.8.12 (Beryllium) and salt-master 2016.3.1 (Boron)

Under 2015.8.12 no exception is raised and it the flow of the code doesn't change.
On 2016.3.1 the AssertionError is raised when the master restarts this just reconnects to the sock in that case and tries it again.  Its kind of a dirty way to fix it, but I can't think of a better one at the moment.

Output below showing it reconnecting to the sock after a master restart.

```
# Initialization on first run
[DEBUG   ] SaltEvent PUB socket URI: /var/run/salt/master/master_event_pub.ipc
[DEBUG   ] SaltEvent PULL socket URI: /var/run/salt/master/master_event_pull.ipc
[DEBUG   ] Initializing new IPCClient for path: /var/run/salt/master/master_event_pub.ipc
[INFO    ] Starting Event-timer
[INFO    ] Starting Stat-timer
[INFO    ] Entering main event loop
[INFO    ] Listening on: /var/run/salt/master/master_event_pub.ipc
[DEBUG   ] Stat-timer finished, calling reference
[DEBUG   ] Matching on return:salt/job/20161012160331030678/ret/<snip>
[INFO    ] Starting worker #1
[INFO    ] 1# started
[DEBUG   ] resetting the Event-timer
[INFO    ] 1# Worker 'Dump_Worker' setup
[INFO    ] Dump_Worker# dumped 1 events
[DEBUG   ] Stat-timer finished, calling reference
[DEBUG   ] Stat-timer finished, calling reference
[DEBUG   ] Event-timer finished, calling reference
[DEBUG   ] Stat-timer finished, calling reference
# Master restart
[ERROR   ] Exception occurred in Subscriber while handling stream: Already reading
[DEBUG   ] SaltEvent PUB socket URI: /var/run/salt/master/master_event_pub.ipc
[DEBUG   ] SaltEvent PULL socket URI: /var/run/salt/master/master_event_pull.ipc
[DEBUG   ] Initializing new IPCClient for path: /var/run/salt/master/master_event_pub.ipc
[DEBUG   ] Stat-timer finished, calling reference
[DEBUG   ] Joined worker #1
[DEBUG   ] Matching on return:salt/job/20161012160523092680/ret/<snip>
[INFO    ] Starting worker #2
[DEBUG   ] resetting the Event-timer
# Next run completes
[INFO    ] 2# started
[INFO    ] 2# Worker 'Dump_Worker' setup
[INFO    ] Dump_Worker# dumped 1 events
```
